### PR TITLE
Add folding marks compliant with standard german C6/C5-envelopes

### DIFF
--- a/_extensions/quarto-letter/typst-template.typ
+++ b/_extensions/quarto-letter/typst-template.typ
@@ -77,23 +77,33 @@
   )
 
 
-    // Link-Farbe
-    show link: set text(fill: rgb("185191"))
+  // Link-Farbe
+  show link: set text(fill: rgb("185191"))
 
-    // Seitengröße und -ränder festlegen
-    set page(
-        paper: paper,
-        margin: (
-            top: mtop,
-            bottom: mbottom,
-            left: mleft,
-            right: mright
-        ),
-        numbering: numbering,
-        number-align: number-align,
-        header: align(center)[#image(logo_path, width: logowidth)],
-        header-ascent: logoascent,
-        footer: align(right)[#text(9pt)[Seite #context counter(page).display("1 von 1",both: true,)]]
+  // Seitengröße und -ränder festlegen, Faltmarken einfügen
+  set page(
+    paper: paper,
+    margin: (
+        top: mtop,
+        bottom: mbottom,
+        left: mleft,
+        right: mright
+    ),
+    numbering: numbering,
+    number-align: number-align,
+    header: align(center)[#image(logo_path, width: logowidth)],
+    header-ascent: logoascent,
+    footer: align(right)[#text(9pt)[Seite #context counter(page).display("1 von 1", both: true,)]],
+    background: {
+        //  Set A - should be correct?
+        place(top + left, dx: -0cm, line(start: (0%, +10.3cm ), end: (8%, +10.3cm), stroke: (thickness: 0.2pt, paint: black))) 
+        place(top + left, dx: -0cm, line(start: (0%, +15.1cm ), end: (6%, +15.1cm), stroke: (thickness: 0.2pt, paint: black)))
+        place(top + left, dx: -0cm, line(start: (0%, +20.5cm ), end: (8%, +20.5cm), stroke: (thickness: 0.2pt, paint: black)))
+        //  Set B - experimental
+        // place(top + left, dx: -0cm, line(start: (0%, 50mm  ), end: (4%, 50mm), stroke: (thickness: 0.1pt,paint: red)))
+        // place(top + left, dx: -0cm, line(start: (0%, 50%   ), end: (6%, 50%), stroke: (thickness: 0.1pt,paint: red)))
+        // place(top + left, dx: -0cm, line(start: (0%, 155mm ), end: (4%, 155mm), stroke: (thickness: 0.1pt,paint: red)))
+    }
   )
 
   v(15mm) //insgesamt 40mm Abstand vom Rand

--- a/template.qmd
+++ b/template.qmd
@@ -40,8 +40,5 @@ ich wende mich heute an Sie mit einer wichtigen Mitteilung.
 
 
 ```{=typst}
-#lorem(50)
+#lorem(5000)
 ```
-
-
-


### PR DESCRIPTION
This PR adds three horizontal lines at the left edge of the paper, allowing for easier folding at 50% paper-height, and at the dimensions needed for folding DIN A4-paper to fit normal german envelopes - while keeping the address-field in the envelope's viewport. 

![grafik](https://github.com/user-attachments/assets/fb2220fa-7835-48cf-80ba-d611c780dec0)
![grafik](https://github.com/user-attachments/assets/7fc5f8e0-4704-4aa8-930d-e9aed42768ec)


Note:
- These dimensions are hard-coded, and were not tested against other paper dimensions, as I have neither a need, nor the ability to check them because I cannot print other dimensions without significant upfront work.


