### PR TITLE
If a single attachment is provided, its string is split by letter in typst template, with each character getting listed as a separate entry in the attachment-list

### DIFF
--- a/_extensions/quarto-letter/typst-template.typ
+++ b/_extensions/quarto-letter/typst-template.typ
@@ -189,10 +189,18 @@
   v(5mm)
 
   if anlagen != none [
-    #text(11pt)[Anlage(n):
+    #if type(anlagen) == str [  // a single attachment
+      #text(11pt)[Anlage:
+      - #anlagen
+      ]
+    ] else if type(anlagen) == array [                      // multiple attachments. also handles empty entries in the list.
+      #text(11pt)[Anlagen(n):
         #for a in anlagen [
-          - #a
+          #if a != "" [
+            - #a
+          ]
         ]
+      ]
     ]
   ]
 }


### PR DESCRIPTION
Hello,

I found an other small bug which I managed to solve, this time related to the attachment-listing:

Currently, designating a single attachment for a letter, e.g. setting

``````qmd
```
# [...] other config
attachment:
  - Lebenslauf
format:
  quarto-letter-typst
---


ich wende mich heute an Sie mit einer wichtigen Mitteilung.


```{=typst}
#lorem(50)
```
``````

will yield the following erroneous output:

![grafik](https://github.com/user-attachments/assets/d4e111aa-e6af-4fc2-9cac-117ef27d0892)


This issue notably only occurs when the list in key `attachment` contains only a single entry. For 2+ entries:

```yml
attachment:
  - Lebenslauf
  - Unterlassungserklärung
format:
  quarto-letter-typst
```

 this does not occur:
 
 
![grafik](https://github.com/user-attachments/assets/b1c0273a-871a-4943-9ef8-b25aa8bd79b8)


The provided changes rectify this issue, yielding for a single entry the following:

![grafik](https://github.com/user-attachments/assets/975d6a61-f455-48aa-82a3-e02fa4bf7a6c)


Additionally, empty entries

```yml
attachment:
  - 
```

will no longer produce an empty bullet-point in the rendered list.



Thank you.
Sincerely,
~Gw