### PR TITLE
The entries for telefon (and e-mail/website) present in the sender's block get printed even if their values are not set

### DIFF
--- a/_extensions/quarto-letter/typst-template.typ
+++ b/_extensions/quarto-letter/typst-template.typ
@@ -139,11 +139,17 @@
                            #v(-4mm)
                            #text(8pt)[#sendplz] #text(8pt)[#sendort]
                            #v(-1mm)
-                           #text(8pt)[Telefon: #sendtelefon]
+                           #if sendtelefon != "" [
+                            #text(8pt)[Telefon: #sendtelefon]
+                           ]
                            #v(-2mm)
-                           #text(8pt)[#sendemail]
+                           #if sendemail != "" [
+                            #text(8pt)[#sendemail]
+                           ]
                            #v(-3mm)
-                           #text(8pt)[#sendwww]
+                           #if sendwww != "" [
+                            #text(8pt)[#sendwww]
+                           ]
                            #linebreak()
                            #if aktenzeichen != "" [
                               #text(8pt)[Aktenzeichen: #aktenzeichen]


### PR DESCRIPTION
This PR resolves an issue related to the string `Telefon: ` getting printed to the sender's header even if the `sender.telefon`-field is unassigned. Therefore, currently the following template 

``````qmd
---
sender:
  firstline: "Ihr Fachmann für Alles"
  graduate: Prof. Dr.
  firstname: Georg
  lastname: Mustermann
  street: Reinarzstr. 49
  plz: 47805
  city: Krefeld
  country: Deutschland
  telefon: 
  email: 
  www: 
  
recipient:
  - Erna Empfängerin
  - Gesundheitsamt FB13
  - Unter der Brücke 17
  - 12345 Empfangsstadt
  - Germany
# ------------------------------------------------  
date: 2022-12-24
filenumber: "22-A-01"
#signature: my-signature.png # bring your own file 
#signature: ""               # no signature
#logo: my-logo.png           # bring your own file 
#logowidth: 90mm
subject: Meine gute Idee
opening: Sehr geehrte Frau Empfängerin,
closing: Mit freundlichen Grüßen
attachment:
  - Lebenslauf
  - Unterlassungserklärung
format:
  quarto-letter-typst
---


ich wende mich heute an Sie mit einer wichtigen Mitteilung.


```{=typst}
#lorem(5000)
```


``````

will yield



![grafik](https://github.com/user-attachments/assets/2c0712fb-edf8-4f45-9978-3d232f2b11bb)

This is not optimal, obviously.

The suggested changes will print each of the following entries only iff they are assigned:

![grafik](https://github.com/user-attachments/assets/99ca0cc0-6932-453a-b324-7e0dadf925d5)


While this is technically\* only necessary for the telephone-field (as it is the only one which has a hard-coded string in it), I deemed it sensible to extend the checks to other sender-related entries for the sake of robustness.

Thank you.
Sincerely,
~Gw